### PR TITLE
Use cached invite view element

### DIFF
--- a/froggyhub_ui/app.js
+++ b/froggyhub_ui/app.js
@@ -69,7 +69,7 @@ function createEvent(e){
   };
   save(data);
   renderAll();
-  document.getElementById('invite').scrollIntoView({behavior:'smooth'});
+  els.inviteView.scrollIntoView({behavior:'smooth'});
 }
 
 // Onboarding


### PR DESCRIPTION
## Summary
- Scroll to the invite view using the already cached DOM element after creating an event.

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const elements = {};
global.document = { getElementById(id){ return elements[id] || (elements[id] = {}); } };
const storage = {};
global.localStorage = { getItem(k){ return storage[k] || null; }, setItem(k,v){ storage[k]=v; } };
const code = fs.readFileSync('froggyhub_ui/app.js','utf8').split('\n').slice(0,74).join('\n');
vm.runInThisContext(code);
renderAll = ()=>{};
Object.assign(elements.eventTitle,{value:'Title'});
Object.assign(elements.eventDate,{value:'2024-01-01'});
Object.assign(elements.eventTime,{value:'12:00'});
Object.assign(elements.eventDesc,{value:''});
Object.assign(elements.eventDress,{value:''});
Object.assign(elements.wishlistUrl,{value:''});
Object.assign(elements.surpriseMode,{checked:false});
Object.assign(elements.wishlistRaw,{value:''});
elements.inviteView.scrollIntoView = ()=>{ console.log('scroll'); };
createEvent({preventDefault(){}});
console.log('Done');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689d10d1afe8833287f842b6ba38850e