### PR TITLE
Clarify speech bubble visibility comment

### DIFF
--- a/froggyhub_ui/index.html
+++ b/froggyhub_ui/index.html
@@ -292,7 +292,7 @@ function setScene(scene){
   body.classList.remove('scene-intro','scene-pond','scene-final');
   body.classList.add(`scene-${scene}`);
   document.getElementById('slides').style.display=(scene==='pond')?'block':'none';
-  // Реплики видимы только в intro/final (скрыты в CSS для pond)
+  // Реплики скрываем/показываем через JS (speech.style.display) при смене сцен
   speech.style.display=(scene==='pond')?'none':'block';
 }
 


### PR DESCRIPTION
## Summary
- Clarify that speech bubbles are hidden or shown via JS `speech.style.display` when switching scenes

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d10d26df48332ae3e3d81e5901014