### PR TITLE
Correct backdrop-filter spacing in speech style

### DIFF
--- a/froggyhub_ui/index.html
+++ b/froggyhub_ui/index.html
@@ -75,7 +75,7 @@
   }
 
   /* Реплики/кнопки */
-  .speech{position:absolute;left:50%;top:72%;transform:translate(-50%,0);max-width:min(760px,92vw);background:rgba(255,255,255,.12);border:2px solid rgba(255,255,255,.35);border-radius:18px;padding:14px 18px;color:#eafff2;backdrop-filter:blur(2px) saturate(130%);box-shadow:0 10px 0 rgba(0,0,0,.12)}
+  .speech{position:absolute;left:50%;top:72%;transform:translate(-50%,0);max-width:min(760px,92vw);background:rgba(255,255,255,.12);border:2px solid rgba(255,255,255,.35);border-radius:18px;padding:14px 18px;color:#eafff2;backdrop-filter: blur(2px) saturate(130%);box-shadow:0 10px 0 rgba(0,0,0,.12)}
   .speech strong{color:#fff}
   .speech .actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:10px}
   body.scene-pond .speech{display:none}


### PR DESCRIPTION
## Summary
- tidy the `.speech` CSS rule to properly space `backdrop-filter: blur(2px) saturate(130%)`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d10d058e48332849d93c26a1eb85b